### PR TITLE
Update installation instructions for non-npm usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ A small structural-only zero-dependency Web Component for responsive `<table>` e
 
 ## Installation
 
-Install via [npm on `@zachleat/table-saw`](https://www.npmjs.com/package/@zachleat/table-saw).
+For a truly zero-dependency experience, [download a tagged version](https://github.com/zachleat/table-saw/tags) and follow [the usage instructions above](#examples).
+
+Or, install via [npm on `@zachleat/table-saw`](https://www.npmjs.com/package/@zachleat/table-saw).
 
 ```sh
 npm install @zachleat/table-saw


### PR DESCRIPTION
## Description

In [this post](https://adactio.com/links/20512), @adactio notes:

> I just wish the installation didn’t assume that you’re using npm …it’s not really “zero dependency” if it depends on that.

Easy enough! This commit adds a brief sentence on how to download a copy of table-saw without using npm or other package management tooling.