### PR TITLE
Fix label rendering issue inside of <details>

### DIFF
--- a/table-saw.js
+++ b/table-saw.js
@@ -113,7 +113,7 @@ table-saw.${this._identifier} {
 				}
 			}
 
-			return cell.innerText.trim()
+			return cell.textContent.trim()
 		});
 		if(labels.length === 0) {
 			this._needsStylesheet = false;

--- a/table-saw.js
+++ b/table-saw.js
@@ -113,7 +113,12 @@ table-saw.${this._identifier} {
 				}
 			}
 
-			return cell.textContent.trim()
+			let label = cell.innerText.trim();
+			if (label === "") {
+				label = cell.textContent.trim();
+			}
+
+			return label;
 		});
 		if(labels.length === 0) {
 			this._needsStylesheet = false;


### PR DESCRIPTION
Right now if you use `<table-saw>` inside of `<details>` it doesn't correctly display labels: https://codepen.io/cbirdsong/full/VYaOJJP

I guess this is because the labels are fetched using `innerText`. MDN says: 

> `innerText` is aware of the rendered appearance of text, while `textContent` is not.

> If the element itself is not [being rendered](https://html.spec.whatwg.org/multipage/rendering.html#being-rendered) (for example, is detached from the document or is hidden from view), the returned value is the same as the [Node.textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) property

It sure sounds like it should work, but it doesn't. 

This fix first tries to use `innerText`, checks to see if it's empty, and falls back to `textContent` if that's the case: https://codepen.io/cbirdsong/full/WbwBVQY